### PR TITLE
Add unowning storage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,6 @@ publish = false
 [features]
 
 [dependencies]
+
+[dev-dependencies]
+cool_asserts = "1.1.1"

--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -1,11 +1,11 @@
 use {
     crate::{
-        polyfill::layout_for_meta, Handle, MultipleStorage, PinningStorage,
-        SharedMutabilityStorage, SliceStorage, Storage,
+        polyfill::layout_for_meta, MultipleStorage, PinningStorage, SharedMutabilityStorage,
+        SliceStorage, Storage,
     },
     core::{
         alloc::{AllocError, Allocator, Layout},
-        ptr::{NonNull, Pointee},
+        ptr::{metadata, NonNull, Pointee},
     },
 };
 
@@ -20,54 +20,58 @@ impl<A: Allocator> AllocStorage<A> {
     }
 }
 
-unsafe impl<A: Allocator> SharedMutabilityStorage for AllocStorage<A> {}
-unsafe impl<A: Allocator> MultipleStorage for AllocStorage<A> {}
-unsafe impl<A: Allocator> PinningStorage for AllocStorage<A> {}
-unsafe impl<A: Allocator> Storage for AllocStorage<A> {
-    type Handle<T: ?Sized> = NonNull<T>;
+unsafe impl<A: Allocator, T: ?Sized> SharedMutabilityStorage<T> for AllocStorage<A> {}
+unsafe impl<A: Allocator, T: ?Sized> MultipleStorage<T> for AllocStorage<A> {}
+unsafe impl<A: Allocator, T: ?Sized> PinningStorage<T> for AllocStorage<A> {}
+unsafe impl<A: Allocator, T: ?Sized> Storage<T> for AllocStorage<A> {
+    type Handle = NonNull<T>;
 
-    unsafe fn create<T: ?Sized>(
+    unsafe fn create(
         &mut self,
         meta: <T as Pointee>::Metadata,
-    ) -> Result<Self::Handle<T>, AllocError> {
+    ) -> Result<Self::Handle, AllocError> {
         let layout = layout_for_meta::<T>(meta).ok_or(AllocError)?;
         let ptr = self.alloc.allocate(layout)?;
         Ok(NonNull::from_raw_parts(ptr.cast(), meta))
     }
 
-    unsafe fn destroy<T: ?Sized>(&mut self, handle: Self::Handle<T>) {
+    unsafe fn destroy(&mut self, handle: Self::Handle) {
         let layout = Layout::for_value_raw(handle.as_ptr());
         self.alloc.deallocate(handle.cast(), layout)
     }
 
-    unsafe fn resolve<T: ?Sized>(&self, handle: Self::Handle<T>) -> NonNull<T> {
+    unsafe fn resolve_metadata(&self, handle: Self::Handle) -> <T as Pointee>::Metadata {
+        metadata(handle.as_ptr())
+    }
+
+    unsafe fn resolve(&self, handle: Self::Handle) -> NonNull<T> {
         handle
     }
 
-    unsafe fn resolve_mut<T: ?Sized>(&mut self, handle: Self::Handle<T>) -> NonNull<T> {
+    unsafe fn resolve_mut(&mut self, handle: Self::Handle) -> NonNull<T> {
         handle
     }
 }
 
-unsafe impl<A: Allocator> SliceStorage for AllocStorage<A> {
-    unsafe fn grow<T>(
+unsafe impl<A: Allocator, T> SliceStorage<T> for AllocStorage<A> {
+    unsafe fn grow(
         &mut self,
-        handle: Self::Handle<[T]>,
+        handle: Self::Handle,
         new_len: usize,
-    ) -> Result<Self::Handle<[T]>, AllocError> {
-        let meta = handle.metadata();
+    ) -> Result<Self::Handle, AllocError> {
+        let meta = self.resolve_metadata(handle);
         let old_layout = Layout::for_value_raw(handle.as_ptr());
         let new_layout = Layout::array::<T>(new_len).map_err(|_| AllocError)?;
         let ptr = self.alloc.grow(handle.cast(), old_layout, new_layout)?;
         Ok(NonNull::from_raw_parts(ptr.cast(), meta))
     }
 
-    unsafe fn shrink<T>(
+    unsafe fn shrink(
         &mut self,
-        handle: Self::Handle<[T]>,
+        handle: Self::Handle,
         new_len: usize,
-    ) -> Result<Self::Handle<[T]>, AllocError> {
-        let meta = handle.metadata();
+    ) -> Result<Self::Handle, AllocError> {
+        let meta = self.resolve_metadata(handle);
         let old_layout = Layout::for_value_raw(handle.as_ptr());
         let new_layout = Layout::array::<T>(new_len).map_err(|_| AllocError)?;
         let ptr = self.alloc.shrink(handle.cast(), old_layout, new_layout)?;

--- a/src/inline.rs
+++ b/src/inline.rs
@@ -6,6 +6,7 @@ use {
     core::{
         alloc::{AllocError, Layout},
         cmp::Ordering,
+        hash::{Hash, Hasher},
         mem::MaybeUninit,
         ptr::{NonNull, Pointee},
     },
@@ -40,13 +41,13 @@ impl<DataStore> InlineStorage<DataStore> {
     }
 }
 
-unsafe impl<DataStore> Storage for InlineStorage<DataStore> {
-    type Handle<T: ?Sized> = InlineStorageHandle<T>;
+unsafe impl<DataStore, T: ?Sized> Storage<T> for InlineStorage<DataStore> {
+    type Handle = InlineStorageHandle<T>;
 
-    unsafe fn create<T: ?Sized>(
+    unsafe fn create(
         &mut self,
         meta: <T as core::ptr::Pointee>::Metadata,
-    ) -> Result<Self::Handle<T>, AllocError> {
+    ) -> Result<Self::Handle, AllocError> {
         let available_layout = Layout::new::<DataStore>();
         let needed_layout = layout_for_meta::<T>(meta).ok_or(AllocError)?;
         if layout_fits_in(needed_layout, available_layout) {
@@ -56,24 +57,24 @@ unsafe impl<DataStore> Storage for InlineStorage<DataStore> {
         }
     }
 
-    unsafe fn destroy<T: ?Sized>(&mut self, _handle: Self::Handle<T>) {}
+    unsafe fn destroy(&mut self, _handle: Self::Handle) {}
 
-    unsafe fn resolve<T: ?Sized>(&self, handle: Self::Handle<T>) -> NonNull<T> {
+    unsafe fn resolve_metadata(&self, handle: Self::Handle) -> <T as Pointee>::Metadata {
+        handle.meta
+    }
+
+    unsafe fn resolve(&self, handle: Self::Handle) -> NonNull<T> {
         let ptr = NonNull::new_unchecked(self.data.as_ptr() as *mut ());
         NonNull::from_raw_parts(ptr.cast(), handle.meta)
     }
 
-    unsafe fn resolve_mut<T: ?Sized>(&mut self, handle: Self::Handle<T>) -> NonNull<T> {
+    unsafe fn resolve_mut(&mut self, handle: Self::Handle) -> NonNull<T> {
         let ptr = NonNull::new_unchecked(self.data.as_mut_ptr() as *mut ());
         NonNull::from_raw_parts(ptr, handle.meta)
     }
 }
 
-unsafe impl<T: ?Sized> Handle<T> for InlineStorageHandle<T> {
-    fn metadata(self) -> <T as Pointee>::Metadata {
-        self.meta
-    }
-}
+unsafe impl<T: ?Sized> Handle<T> for InlineStorageHandle<T> {}
 
 impl<T: ?Sized> InlineStorageHandle<T> {
     pub fn new(meta: <T as Pointee>::Metadata) -> Self {
@@ -104,5 +105,11 @@ impl<T: ?Sized> PartialOrd for InlineStorageHandle<T> {
 impl<T: ?Sized> Ord for InlineStorageHandle<T> {
     fn cmp(&self, rhs: &Self) -> Ordering {
         self.meta.cmp(&rhs.meta)
+    }
+}
+
+impl<T: ?Sized> Hash for InlineStorageHandle<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.meta.hash(state)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,6 @@
 #![feature(
     allocator_api,
     dropck_eyepatch,
-    generic_associated_types,
     layout_for_ptr,
     specialization,
     ptr_metadata
@@ -40,6 +39,7 @@ mod inline;
 mod polyfill;
 mod raw_box;
 mod raw_vec;
+mod referenced;
 mod small;
 mod traits;
 
@@ -49,6 +49,7 @@ pub use crate::{
     inline::{InlineStorage, InlineStorageHandle},
     raw_box::RawBox,
     raw_vec::RawVec,
+    referenced::{RefStorage, RefStorageHandle},
     small::{SmallStorage, SmallStorageHandle},
     traits::{
         Handle, MultipleStorage, PinningStorage, SharedMutabilityStorage, SliceStorage, Storage,

--- a/src/raw_box.rs
+++ b/src/raw_box.rs
@@ -1,15 +1,19 @@
 use {
-    crate::{Handle, Storage},
-    core::{alloc::AllocError, ptr::Pointee},
+    crate::Storage,
+    core::{
+        alloc::AllocError,
+        mem::ManuallyDrop,
+        ptr::{self, Pointee},
+    },
 };
 
 /// A raw box around some storage. Bundles the storage and its handle.
-pub struct RawBox<T: ?Sized, S: Storage> {
-    handle: S::Handle<T>,
+pub struct RawBox<T: ?Sized, S: Storage<T>> {
+    handle: S::Handle,
     storage: S,
 }
 
-impl<T: ?Sized, S: Storage> RawBox<T, S> {
+impl<T: ?Sized, S: Storage<T>> RawBox<T, S> {
     /// Create a new box for the object described by the given metadata.
     ///
     /// The object is not initialized.
@@ -34,27 +38,37 @@ impl<T: ?Sized, S: Storage> RawBox<T, S> {
         }
     }
 
+    pub unsafe fn from_raw_parts(handle: S::Handle, storage: S) -> Self {
+        Self { handle, storage }
+    }
+
+    pub fn into_raw_parts(self) -> (S::Handle, S) {
+        let this = ManuallyDrop::new(self);
+        (this.handle, unsafe { ptr::read(&this.storage) })
+    }
+
     /// Get a pointer valid *for reads only* to the object.
     ///
-    /// The pointer is invalidated when the box is moved or used mutably.
+    /// The pointer is invalidated when the box is moved or used by mutable
+    /// reference.
     pub fn as_ptr(&self) -> *const T {
         unsafe { self.storage.resolve(self.handle).as_ptr() }
     }
 
     /// Get a pointer valid for reads and writes to the object.
     ///
-    /// The pointer is invalidated when the box is moved or used mutably.
+    /// The pointer is invalidated when the box is moved or used by reference.
     pub fn as_mut_ptr(&mut self) -> *mut T {
         unsafe { self.storage.resolve_mut(self.handle).as_ptr() }
     }
 
     /// Get the metadata of the inner object.
     pub fn metadata(&self) -> <T as Pointee>::Metadata {
-        self.handle.metadata()
+        unsafe { self.storage.resolve_metadata(self.handle) }
     }
 }
 
-unsafe impl<#[may_dangle] T: ?Sized, S: Storage> Drop for RawBox<T, S> {
+unsafe impl<#[may_dangle] T: ?Sized, S: Storage<T>> Drop for RawBox<T, S> {
     fn drop(&mut self) {
         unsafe { self.storage.destroy(self.handle) }
     }

--- a/src/raw_vec.rs
+++ b/src/raw_vec.rs
@@ -1,7 +1,4 @@
-use {
-    crate::{Handle, SliceStorage},
-    core::alloc::AllocError,
-};
+use {crate::SliceStorage, core::alloc::AllocError};
 
 /// A raw vec around some slice storage. Bundles the storage and its handle.
 ///
@@ -9,12 +6,12 @@ use {
 /// raw vec handles amortized growth; this raw vec just does exactly as asked.
 ///
 /// [alloc's `RawVec`]: https://github.com/rust-lang/rust/blob/master/library/alloc/src/raw_vec.rs
-pub struct RawVec<T, S: SliceStorage> {
-    handle: S::Handle<[T]>,
+pub struct RawVec<T, S: SliceStorage<T>> {
+    handle: S::Handle,
     storage: S,
 }
 
-impl<T, S: SliceStorage> RawVec<T, S> {
+impl<T, S: SliceStorage<T>> RawVec<T, S> {
     /// Create a new empty growable slice in the given storage.
     pub fn new(mut storage: S) -> Result<Self, S> {
         match unsafe { storage.create(0) } {
@@ -39,7 +36,7 @@ impl<T, S: SliceStorage> RawVec<T, S> {
 
     /// Get the length of the slice.
     pub fn len(&self) -> usize {
-        self.handle.metadata()
+        unsafe { self.storage.resolve_metadata(self.handle) }
     }
 
     /// Grow the length of the slice to `new_len`. Does not change the length
@@ -65,7 +62,7 @@ impl<T, S: SliceStorage> RawVec<T, S> {
     }
 }
 
-unsafe impl<#[may_dangle] T, S: SliceStorage> Drop for RawVec<T, S> {
+unsafe impl<#[may_dangle] T, S: SliceStorage<T>> Drop for RawVec<T, S> {
     fn drop(&mut self) {
         unsafe { self.storage.destroy(self.handle) }
     }

--- a/src/referenced.rs
+++ b/src/referenced.rs
@@ -1,0 +1,132 @@
+use {
+    crate::{Handle, Storage},
+    core::{
+        alloc::AllocError,
+        cmp::Ordering,
+        hash::{Hash, Hasher},
+        mem::ManuallyDrop,
+        ptr::{metadata, NonNull, Pointee},
+    },
+};
+
+/// A storage wrapper around `&mut T`.
+///
+/// This storage cannot be used to [`create`][Self::create] new handles.
+/// Instead, when created, there is a single handle to the contents of the
+/// wrapped reference. Attempting to [`destroy`][Self::destroy] this handle
+/// is a no-op.
+pub struct RefStorage<'a, T: ?Sized> {
+    data: &'a mut T,
+}
+
+/// A handle into a [`RefStorage]`.
+pub struct RefStorageHandle;
+
+impl<'a, T: ?Sized> RefStorage<'a, T> {
+    /// Create a new borrowed storage.
+    pub fn new(data: &'a mut T) -> Self {
+        Self { data }
+    }
+
+    /// Get the wrapped reference without going through a storage handle.
+    pub fn get(&self) -> &T {
+        self.data
+    }
+
+    /// Get the wrapped reference without going through a storage handle.
+    pub fn get_mut(&mut self) -> &mut T {
+        self.data
+    }
+}
+
+unsafe impl<T: ?Sized> Storage<T> for RefStorage<'_, T> {
+    type Handle = RefStorageHandle;
+
+    /// Always returns an error. See the type docs for more info.
+    unsafe fn create(
+        &mut self,
+        _meta: <T as core::ptr::Pointee>::Metadata,
+    ) -> Result<Self::Handle, AllocError> {
+        Err(AllocError)
+    }
+
+    // No-op. See the type docs for more info.
+    unsafe fn destroy(&mut self, _handle: Self::Handle) {}
+
+    unsafe fn resolve_metadata(&self, _handle: Self::Handle) -> <T as Pointee>::Metadata {
+        metadata(self.data)
+    }
+
+    unsafe fn resolve(&self, _handle: Self::Handle) -> NonNull<T> {
+        NonNull::from(self.get())
+    }
+
+    unsafe fn resolve_mut(&mut self, _handle: Self::Handle) -> NonNull<T> {
+        NonNull::from(self.get_mut())
+    }
+}
+
+unsafe impl<T: ?Sized> Storage<T> for RefStorage<'_, ManuallyDrop<T>> {
+    type Handle = RefStorageHandle;
+
+    /// Always returns an error. See the type docs for more info.
+    unsafe fn create(
+        &mut self,
+        _meta: <T as core::ptr::Pointee>::Metadata,
+    ) -> Result<Self::Handle, AllocError> {
+        Err(AllocError)
+    }
+
+    // No-op. See the type docs for more info.
+    unsafe fn destroy(&mut self, _handle: Self::Handle) {}
+
+    unsafe fn resolve_metadata(&self, _handle: Self::Handle) -> <T as Pointee>::Metadata {
+        metadata(self.data as *const ManuallyDrop<T> as *mut T)
+    }
+
+    unsafe fn resolve(&self, _handle: Self::Handle) -> NonNull<T> {
+        NonNull::new_unchecked(self.data as *const ManuallyDrop<T> as *mut T)
+    }
+
+    unsafe fn resolve_mut(&mut self, _handle: Self::Handle) -> NonNull<T> {
+        NonNull::new_unchecked(self.data as *mut ManuallyDrop<T> as *mut T)
+    }
+}
+
+unsafe impl<T: ?Sized> Handle<T> for RefStorageHandle {}
+
+impl RefStorageHandle {
+    pub fn new() -> Self {
+        RefStorageHandle
+    }
+}
+
+impl Copy for RefStorageHandle {}
+impl Clone for RefStorageHandle {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl Eq for RefStorageHandle {}
+impl PartialEq for RefStorageHandle {
+    fn eq(&self, _rhs: &Self) -> bool {
+        true
+    }
+}
+
+impl PartialOrd for RefStorageHandle {
+    fn partial_cmp(&self, rhs: &Self) -> Option<Ordering> {
+        Some(self.cmp(rhs))
+    }
+}
+
+impl Ord for RefStorageHandle {
+    fn cmp(&self, _rhs: &Self) -> Ordering {
+        Ordering::Equal
+    }
+}
+
+impl Hash for RefStorageHandle {
+    fn hash<H: Hasher>(&self, _state: &mut H) {}
+}

--- a/src/small.rs
+++ b/src/small.rs
@@ -3,6 +3,7 @@ use {
     core::{
         alloc::{AllocError, Allocator},
         cmp::Ordering,
+        hash::{Hash, Hasher},
         ptr::{NonNull, Pointee},
     },
 };
@@ -31,28 +32,27 @@ impl<DataStore, A: Allocator> SmallStorage<DataStore, A> {
     }
 }
 
-unsafe impl<DataStore, A: Allocator> Storage for SmallStorage<DataStore, A> {
-    type Handle<T: ?Sized> = SmallStorageHandle<T>;
+unsafe impl<DataStore, A: Allocator, T: ?Sized> Storage<T> for SmallStorage<DataStore, A> {
+    type Handle = SmallStorageHandle<T>;
 
-    unsafe fn create<T: ?Sized>(
+    unsafe fn create(
         &mut self,
         meta: <T as core::ptr::Pointee>::Metadata,
-    ) -> Result<Self::Handle<T>, AllocError> {
+    ) -> Result<Self::Handle, AllocError> {
         if self.inline.fits::<T>(meta) {
-            self.inline.create::<T>(meta)?;
+            Storage::<T>::create(&mut self.inline, meta)?;
             Ok(SmallStorageHandle { meta })
         } else {
-            let (addr, _) = self.outline.create::<T>(meta)?.to_raw_parts();
-            let addr_handle = self.inline.create::<NonNull<()>>(())?;
+            let (addr, _) = Storage::<T>::create(&mut self.outline, meta)?.to_raw_parts();
+            let addr_handle = self.inline.create(())?;
             *self.inline.resolve_mut(addr_handle).as_ptr() = addr;
             Ok(SmallStorageHandle { meta })
         }
     }
 
-    unsafe fn destroy<T: ?Sized>(&mut self, handle: Self::Handle<T>) {
+    unsafe fn destroy(&mut self, handle: Self::Handle) {
         if self.inline.fits::<T>(handle.meta) {
-            self.inline
-                .destroy::<T>(InlineStorageHandle::new(handle.meta))
+            Storage::<T>::destroy(&mut self.inline, InlineStorageHandle::new(handle.meta));
         } else {
             let addr_handle = InlineStorageHandle::<NonNull<()>>::new(());
             let addr = *self.inline.resolve(addr_handle).as_ref();
@@ -62,36 +62,36 @@ unsafe impl<DataStore, A: Allocator> Storage for SmallStorage<DataStore, A> {
         }
     }
 
-    unsafe fn resolve<T: ?Sized>(&self, handle: Self::Handle<T>) -> NonNull<T> {
+    unsafe fn resolve_metadata(&self, handle: Self::Handle) -> <T as Pointee>::Metadata {
+        handle.meta
+    }
+
+    unsafe fn resolve(&self, handle: Self::Handle) -> NonNull<T> {
+        let meta = handle.meta;
         if self.inline.fits::<T>(handle.meta) {
-            self.inline
-                .resolve::<T>(InlineStorageHandle::new(handle.meta))
+            self.inline.resolve(InlineStorageHandle::new(meta))
         } else {
             let addr_handle = InlineStorageHandle::<NonNull<()>>::new(());
             let addr = *self.inline.resolve(addr_handle).as_ref();
-            let ptr = NonNull::<T>::from_raw_parts(addr, handle.meta);
+            let ptr = NonNull::<T>::from_raw_parts(addr, meta);
             self.outline.resolve(ptr)
         }
     }
 
-    unsafe fn resolve_mut<T: ?Sized>(&mut self, handle: Self::Handle<T>) -> NonNull<T> {
+    unsafe fn resolve_mut(&mut self, handle: Self::Handle) -> NonNull<T> {
+        let meta = handle.meta;
         if self.inline.fits::<T>(handle.meta) {
-            self.inline
-                .resolve_mut::<T>(InlineStorageHandle::new(handle.meta))
+            self.inline.resolve_mut(InlineStorageHandle::new(meta))
         } else {
             let addr_handle = InlineStorageHandle::<NonNull<()>>::new(());
             let addr = *self.inline.resolve(addr_handle).as_ref();
-            let ptr = NonNull::<T>::from_raw_parts(addr, handle.meta);
+            let ptr = NonNull::<T>::from_raw_parts(addr, meta);
             self.outline.resolve_mut(ptr)
         }
     }
 }
 
-unsafe impl<T: ?Sized> Handle<T> for SmallStorageHandle<T> {
-    fn metadata(self) -> <T as Pointee>::Metadata {
-        self.meta
-    }
-}
+unsafe impl<T: ?Sized> Handle<T> for SmallStorageHandle<T> {}
 
 impl<T: ?Sized> SmallStorageHandle<T> {
     pub fn new(meta: <T as Pointee>::Metadata) -> Self {
@@ -122,5 +122,11 @@ impl<T: ?Sized> PartialOrd for SmallStorageHandle<T> {
 impl<T: ?Sized> Ord for SmallStorageHandle<T> {
     fn cmp(&self, rhs: &Self) -> Ordering {
         self.meta.cmp(&rhs.meta)
+    }
+}
+
+impl<T: ?Sized> Hash for SmallStorageHandle<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.meta.hash(state)
     }
 }

--- a/tests/box_tricks.rs
+++ b/tests/box_tricks.rs
@@ -1,0 +1,61 @@
+#![feature(allocator_api, ptr_metadata)]
+#![allow(clippy::missing_safety_doc)]
+
+use {
+    cool_asserts::assert_panics,
+    std::{
+        alloc::{handle_alloc_error, Global, Layout},
+        mem::{size_of, size_of_val, ManuallyDrop},
+        panic::UnwindSafe,
+    },
+    storage_api::{AllocStorage, RawBox, RefStorage, RefStorageHandle, Storage},
+};
+
+pub struct Box<T: ?Sized, S: Storage<T> = AllocStorage<Global>> {
+    raw: RawBox<T, S>,
+}
+
+impl<T> Box<T> {
+    pub fn new(it: T) -> Self {
+        unsafe {
+            let mut raw = RawBox::<T, _>::new((), AllocStorage::new(Global))
+                .unwrap_or_else(|_| handle_alloc_error(Layout::new::<T>()));
+            raw.as_mut_ptr().write(it);
+            Box { raw }
+        }
+    }
+}
+
+impl<T: ?Sized, S: Storage<T>> Drop for Box<T, S> {
+    fn drop(&mut self) {
+        unsafe { self.raw.as_mut_ptr().drop_in_place() }
+    }
+}
+
+type MoveRef<'a, T> = Box<T, RefStorage<'a, ManuallyDrop<T>>>;
+
+impl<'a, T: ?Sized> MoveRef<'a, T> {
+    pub unsafe fn new_unchecked(it: &'a mut ManuallyDrop<T>) -> Self {
+        Self {
+            raw: RawBox::from_raw_parts(RefStorageHandle, RefStorage::new(it)),
+        }
+    }
+}
+
+impl<T: ?Sized, S: Storage<T>> UnwindSafe for Box<T, S> {}
+
+#[test]
+fn move_ref() {
+    struct PanicDrop {
+        message: &'static str,
+    }
+    impl Drop for PanicDrop {
+        fn drop(&mut self) {
+            panic!("{}", self.message)
+        }
+    }
+    let mut place = ManuallyDrop::new(PanicDrop { message: "dropped" });
+    let my_ref = unsafe { MoveRef::new_unchecked(&mut place) };
+    assert_eq!(size_of_val(&my_ref), size_of::<&mut PanicDrop>());
+    assert_panics!(drop(my_ref), includes("dropped"));
+}


### PR DESCRIPTION
This changes `Storage` from a GAT user to `Storage<T>`, to allow `&mut T` to pretend to be `Storage<T>`.

This is required to emulate `&move`, where the storage is taken from an existing place and the ownership of the value is taken as well.