### PR TITLE
Implement storage API over Layout

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,10 +2,9 @@
 //!
 //! Describing the raw storage API, we have:
 //!
-//! - [`Storage`]: a storage that can store objects
-//! - [`SliceStorage`]: a storage for growable slices
-//! - [`MultipleStorage`]: a storage that can store multiple objects
-//! - [`SharedMutabilityStorage`] and [`PinningStorage`]
+//! - [`Storage`]: a storage that manages a single memory allocation
+//! - [`MultipleStorage`]: a storage that can manage multiple handles
+//! - [`SharedMutabilityStorage`] and [`PinningStorage`] for advanced use
 //!
 //! Providing a safe wrapper around `Storage` use (up to uninit memory):
 //!
@@ -22,15 +21,19 @@
 #![feature(
     allocator_api,
     dropck_eyepatch,
-    generic_associated_types,
+    extern_types,
     layout_for_ptr,
+    let_chains,
+    maybe_uninit_array_assume_init,
     specialization,
     ptr_metadata
 )]
 #![allow(
     clippy::len_without_is_empty,
     clippy::missing_safety_doc,
+    clippy::mut_from_ref,
     clippy::new_without_default,
+    clippy::should_implement_trait,
     incomplete_features,
     unused_unsafe
 )]
@@ -46,11 +49,9 @@ mod traits;
 #[doc(inline)]
 pub use crate::{
     alloc::AllocStorage,
-    inline::{InlineStorage, InlineStorageHandle},
+    inline::InlineStorage,
     raw_box::RawBox,
     raw_vec::RawVec,
-    small::{SmallStorage, SmallStorageHandle},
-    traits::{
-        Handle, MultipleStorage, PinningStorage, SharedMutabilityStorage, SliceStorage, Storage,
-    },
+    small::SmallStorage,
+    traits::{Memory, MultipleStorage, PinningStorage, SharedMutabilityStorage, Storage},
 };

--- a/src/polyfill.rs
+++ b/src/polyfill.rs
@@ -1,24 +1,20 @@
 use core::{
     alloc::Layout,
-    mem,
     ptr::{self, Pointee},
 };
 
 // For now, we're just assuming that metadata passed in describes a valid
 // layout. Ideally, we shouldn't have to, but there's no current way to go from
 // metadata to size without breaking the "must be <= isize::MAX" rule.
-pub(crate) fn layout_for_meta<T: ?Sized>(meta: <T as Pointee>::Metadata) -> Option<Layout> {
+pub(crate) unsafe fn layout_for_metadata<T: ?Sized>(
+    meta: <T as Pointee>::Metadata,
+) -> Option<Layout> {
     let ptr: *const T = ptr::from_raw_parts(ptr::null(), meta);
 
-    // We *need* a way to check that these are safe
+    // We *need* a way to check that this is sound
     unsafe {
         // SAFETY: it's *not*, but there's no way to pre-check
-        let size = mem::size_of_val_raw(ptr);
-        // SAFETY: it's *not*, but there's no way to pre-check
-        let align = mem::align_of_val_raw(ptr);
-
-        // SAFETY: sizeof/alignof return valid size/align
-        Some(Layout::from_size_align_unchecked(size, align))
+        Some(Layout::for_value_raw(ptr))
     }
 }
 

--- a/src/raw_box.rs
+++ b/src/raw_box.rs
@@ -1,15 +1,24 @@
 use {
-    crate::{Handle, Storage},
-    core::{alloc::AllocError, ptr::Pointee},
+    crate::{polyfill::layout_for_metadata, Storage},
+    core::{
+        alloc::Layout,
+        mem::MaybeUninit,
+        ptr::{self, Pointee},
+    },
 };
 
 /// A raw box around some storage. Bundles the storage and its handle.
 pub struct RawBox<T: ?Sized, S: Storage> {
-    handle: S::Handle<T>,
+    handle: S::Handle,
+    metadata: <T as Pointee>::Metadata,
     storage: S,
 }
 
 impl<T: ?Sized, S: Storage> RawBox<T, S> {
+    fn heap_layout(&self) -> Layout {
+        unsafe { layout_for_metadata::<T>(self.metadata).unwrap_unchecked() }
+    }
+
     /// Create a new box for the object described by the given metadata.
     ///
     /// The object is not initialized.
@@ -19,43 +28,82 @@ impl<T: ?Sized, S: Storage> RawBox<T, S> {
     /// # Safety
     ///
     /// - The metadata must describe a layout valid for a rust object.
-    ///   - This exists due to the safety requirements of `size_of_val_raw`
-    ///     and `align_of_val_raw`. I think we need a way to go compute layout
-    ///     from metadata safely, with a check that it produces a valid layout.
+    ///   - This requirement exists due to the safety requirements of
+    ///     `size_of_val_raw` and `align_of_val_raw`. I think we definitely want
+    ///     a way to go compute layout from type and metadata safely, with a
+    ///     check that it produces a valid layout.
     ///   - On each unsized kind, this would imply:
-    ///     - slices: size computation uses saturating/checked multiplication
-    ///     - traits: vtable must always be valid (as a safety invariant)
-    ///     - composites: size computation uses saturating/checked addition
-    ///     - externs: any valid metadata must compute valid size/align or None
-    pub unsafe fn new(meta: <T as Pointee>::Metadata, mut storage: S) -> Result<Self, S> {
-        match storage.create(meta) {
-            Ok(handle) => Ok(RawBox { handle, storage }),
-            Err(AllocError) => Err(storage),
+    ///     - slices: size computation uses saturating/checked multiplication.
+    ///     - traits: vtable must always be valid (as a safety invariant).
+    ///     - composites: size computation uses saturating/checked addition.
+    ///     - externs: any valid metadata must compute valid size/align or
+    ///       indicates that size/align is unknown and/or needs a valid object.
+    ///   - [rust-lang/rust#95832](https://github.com/rust-lang/rust/pull/95832)
+    ///     is an attempt to quantize how expensive it would be to make slice
+    ///     size computation *always* use saturating math.
+    pub unsafe fn new(metadata: <T as Pointee>::Metadata, mut storage: S) -> Result<Self, S> {
+        if let Some(layout) = layout_for_metadata::<T>(metadata)
+        && let Ok(handle) = storage.allocate(layout)
+        {
+            Ok(RawBox { handle, metadata, storage })
+        } else {
+            Err(storage)
         }
     }
 
-    /// Get a pointer valid *for reads only* to the object.
+    /// Get a reference to the boxed object.
+    pub fn as_ref(&self) -> &MaybeUninit<T>
+    where
+        T: Sized,
+    {
+        unsafe { &*(self.as_ptr() as *const _) }
+    }
+
+    /// Get a pointer valid *for reads only* to the boxed object.
     ///
-    /// The pointer is invalidated when the box is moved or used mutably.
+    /// The pointer is invalidated when the box is moved or used by mutable
+    /// reference.
     pub fn as_ptr(&self) -> *const T {
-        unsafe { self.storage.resolve(self.handle).as_ptr() }
+        unsafe {
+            let (addr, _) = self
+                .storage
+                .resolve(self.handle, self.heap_layout())
+                .as_ptr()
+                .to_raw_parts();
+            ptr::from_raw_parts(addr, self.metadata())
+        }
     }
 
-    /// Get a pointer valid for reads and writes to the object.
+    /// Get a mutable reference to the boxed object.
+    pub fn as_mut(&mut self) -> &mut MaybeUninit<T>
+    where
+        T: Sized,
+    {
+        unsafe { &mut *(self.as_mut_ptr() as *mut _) }
+    }
+
+    /// Get a pointer valid for reads and writes to the boxed object.
     ///
-    /// The pointer is invalidated when the box is moved or used mutably.
+    /// The pointer is invalidated when the box is moved or used by reference.
     pub fn as_mut_ptr(&mut self) -> *mut T {
-        unsafe { self.storage.resolve_mut(self.handle).as_ptr() }
+        unsafe {
+            let (addr, _) = self
+                .storage
+                .resolve_mut(self.handle, self.heap_layout())
+                .as_mut_ptr()
+                .to_raw_parts();
+            ptr::from_raw_parts_mut(addr, self.metadata())
+        }
     }
 
-    /// Get the metadata of the inner object.
+    /// Get the metadata of the boxed object.
     pub fn metadata(&self) -> <T as Pointee>::Metadata {
-        self.handle.metadata()
+        self.metadata
     }
 }
 
 unsafe impl<#[may_dangle] T: ?Sized, S: Storage> Drop for RawBox<T, S> {
     fn drop(&mut self) {
-        unsafe { self.storage.destroy(self.handle) }
+        unsafe { self.storage.deallocate(self.handle, self.heap_layout()) }
     }
 }

--- a/src/raw_vec.rs
+++ b/src/raw_vec.rs
@@ -1,6 +1,10 @@
 use {
-    crate::{Handle, SliceStorage},
-    core::alloc::AllocError,
+    crate::{polyfill::layout_for_metadata, Storage},
+    core::{
+        alloc::{AllocError, Layout},
+        mem::MaybeUninit,
+        ptr::{self, Pointee},
+    },
 };
 
 /// A raw vec around some slice storage. Bundles the storage and its handle.
@@ -9,37 +13,61 @@ use {
 /// raw vec handles amortized growth; this raw vec just does exactly as asked.
 ///
 /// [alloc's `RawVec`]: https://github.com/rust-lang/rust/blob/master/library/alloc/src/raw_vec.rs
-pub struct RawVec<T, S: SliceStorage> {
-    handle: S::Handle<[T]>,
+pub struct RawVec<T, S: Storage> {
+    handle: S::Handle,
+    metadata: <[T] as Pointee>::Metadata,
     storage: S,
 }
 
-impl<T, S: SliceStorage> RawVec<T, S> {
+impl<T, S: Storage> RawVec<T, S> {
+    fn heap_layout(&self) -> Layout {
+        Self::heap_layout_for(self.len())
+    }
+
+    fn heap_layout_for(len: usize) -> Layout {
+        unsafe { layout_for_metadata::<[T]>(len).unwrap_unchecked() }
+    }
+
     /// Create a new empty growable slice in the given storage.
     pub fn new(mut storage: S) -> Result<Self, S> {
-        match unsafe { storage.create(0) } {
-            Ok(handle) => Ok(Self { handle, storage }),
-            Err(AllocError) => Err(storage),
+        if let Ok(handle) = storage.allocate(Self::heap_layout_for(0)) {
+            Ok(Self {
+                handle,
+                metadata: 0,
+                storage,
+            })
+        } else {
+            Err(storage)
         }
     }
 
-    /// Get a pointer valid *for reads only* to the slice.
-    ///
-    /// The pointer is invalidated when the vec is moved or used mutably.
-    pub fn as_ptr(&self) -> *const [T] {
-        unsafe { self.storage.resolve(self.handle).as_ptr() }
+    /// Get a reference to the boxed slice.
+    pub fn as_ref(&self) -> &[MaybeUninit<T>] {
+        unsafe {
+            let (addr, _) = self
+                .storage
+                .resolve(self.handle, self.heap_layout())
+                .as_ptr()
+                .to_raw_parts();
+            &*ptr::from_raw_parts(addr, self.len())
+        }
     }
 
-    /// Get a pointer valid for reads and writes to the slice.
-    ///
-    /// The pointer is invalidated when the vec is moved or used mutably.
-    pub fn as_mut_ptr(&mut self) -> *mut [T] {
-        unsafe { self.storage.resolve_mut(self.handle).as_ptr() }
+    /// Get a mutable reference to the boxed slice.
+    pub fn as_mut(&mut self) -> &mut [MaybeUninit<T>] {
+        unsafe {
+            let (addr, _) = self
+                .storage
+                .resolve_mut(self.handle, self.heap_layout())
+                .as_mut_ptr()
+                .to_raw_parts();
+            &mut *ptr::from_raw_parts_mut(addr, self.len())
+        }
     }
 
     /// Get the length of the slice.
     pub fn len(&self) -> usize {
-        self.handle.metadata()
+        self.metadata
     }
 
     /// Grow the length of the slice to `new_len`. Does not change the length
@@ -48,7 +76,14 @@ impl<T, S: SliceStorage> RawVec<T, S> {
         if new_len <= self.len() {
             Ok(())
         } else {
-            self.handle = unsafe { self.storage.grow(self.handle, new_len) }?;
+            self.handle = unsafe {
+                self.storage.grow(
+                    self.handle,
+                    self.heap_layout(),
+                    Self::heap_layout_for(new_len),
+                )
+            }?;
+            self.metadata = new_len;
             Ok(())
         }
     }
@@ -59,14 +94,20 @@ impl<T, S: SliceStorage> RawVec<T, S> {
         if new_len >= self.len() {
             Ok(())
         } else {
-            self.handle = unsafe { self.storage.shrink(self.handle, new_len) }?;
+            self.handle = unsafe {
+                self.storage.shrink(
+                    self.handle,
+                    self.heap_layout(),
+                    Self::heap_layout_for(new_len),
+                )
+            }?;
             Ok(())
         }
     }
 }
 
-unsafe impl<#[may_dangle] T, S: SliceStorage> Drop for RawVec<T, S> {
+unsafe impl<#[may_dangle] T, S: Storage> Drop for RawVec<T, S> {
     fn drop(&mut self) {
-        unsafe { self.storage.destroy(self.handle) }
+        unsafe { self.storage.deallocate(self.handle, self.heap_layout()) }
     }
 }


### PR DESCRIPTION
I *think* this is a simplification, but I've been looking at this API for so long I can't be sure anymore.

This does make the `Storage` API more similar to the `Allocator` API; this could be seen as a positive or a negative.

TL;DR the API change:

<details><summary>Before</summary>

```rust
pub unsafe trait Handle<T: ?Sized>: Copy {
    fn metadata(self) -> <T as Pointee>::Metadata;
}

pub unsafe trait Storage {
    type Handle<T: ?Sized>: Handle<T>;

    unsafe fn create<T: ?Sized>(
        &mut self,
        meta: <T as Pointee>::Metadata,
    ) -> Result<Self::Handle<T>, AllocError>;
    unsafe fn destroy<T: ?Sized>(&mut self, handle: Self::Handle<T>);
    unsafe fn resolve<T: ?Sized>(&self, handle: Self::Handle<T>) -> NonNull<T>;
    unsafe fn resolve_mut<T: ?Sized>(&mut self, handle: Self::Handle<T>) -> NonNull<T>;
}

pub unsafe trait PinningStorage: Storage {}

pub unsafe trait MultipleStorage: Storage {}

pub unsafe trait SharedMutabilityStorage: Storage {}

pub unsafe trait SliceStorage: Storage {
    unsafe fn grow<T>(
        &mut self,
        handle: Self::Handle<[T]>,
        new_len: usize,
    ) -> Result<Self::Handle<[T]>, AllocError>;

    unsafe fn shrink<T>(
        &mut self,
        handle: Self::Handle<[T]>,
        new_len: usize,
    ) -> Result<Self::Handle<[T]>, AllocError>;
}
```
</details>

<details><summary>After</summary>

```rust
pub type Memory = [MaybeUninit<u8>];

pub unsafe trait Storage {
    type Handle: Copy + Ord + Hash + Unpin;

    fn allocate(&mut self, layout: Layout) -> Result<Self::Handle, AllocError>;
    unsafe fn deallocate(&mut self, handle: Self::Handle, layout: Layout);
    unsafe fn resolve(&self, handle: Self::Handle, layout: Layout) -> &Memory;
    unsafe fn resolve_mut(&mut self, handle: Self::Handle, layout: Layout) -> &mut Memory;

    unsafe fn grow(
        &mut self,
        handle: Self::Handle,
        old_layout: Layout,
        new_layout: Layout,
    ) -> Result<Self::Handle, AllocError>;

    unsafe fn shrink(
        &mut self,
        handle: Self::Handle,
        old_layout: Layout,
        new_layout: Layout,
    ) -> Result<Self::Handle, AllocError>;
}

pub unsafe trait PinningStorage: Storage {}

pub unsafe trait MultipleStorage: Storage {
    unsafe fn resolve_many_mut<const N: usize>(
        &mut self,
        handles: [(Self::Handle, Layout); N],
    ) -> [&mut Memory; N];
}

pub unsafe trait SharedMutabilityStorage: Storage {
    unsafe fn resolve_raw(&self, handle: Self::Handle, layout: Layout) -> &mut Memory;
}
```
</details>

Note, however, that there are some just legitimately different choices in the layout API which *could* be replicated in the metadata API. The big difference is typed storage/handles in the metadata case, and fully untyped storage/handles in the layout case. In fact, we don't even use GAT in the layout API.